### PR TITLE
Added `BIG_CONFIG_DISABLE_LOCAL` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This system works well for small projects, as well as huge multi-developer syste
 
 Different environments—such as `development` and `production`—can have their own settings.
 
-A very important feature is that settings are **merged** with inherited default settings. This means you won’t have a “combinatorial explosion of config”[¹](https://12factor.net/config), because each environment only needs to define those values, if any, which are different from the defaults. And they do not need to define *all* of the values for a given config node, only the ones that differ from the default.
+A very important feature is that settings are **merged** with inherited default settings. This means you won’t have a “combinatorial explosion of config”[¹](https://12factor.net/config), because each environment only needs to define those values, if any, which are different from the defaults. And they do not need to define _all_ of the values for a given config node, only the ones that differ from the default.
 
 ## Install
 
@@ -145,3 +145,11 @@ If you don’t like `CONFIG__` as the environment variable prefix, you can use a
 ```javascript
 const config = new Config({ prefix: 'SETTINGS__' });
 ```
+
+### Disabling local configs with \$BIG_CONFIG_DISABLE_LOCAL
+
+The `local` configuration directory has the highest precident: it will override all other configurations. It does this in order to give users the ability to configure their local environment.
+
+However, this is not always desired. One may wish to have a `local` default stored it git, disabling polling a task queue, as an example. But then when one deploys to production, local will override the production configurations.
+
+In order to work around this, we have the option to disable local configurations. To disable local configurations, set the `BIG_CONFIG_DISABLE_LOCAL=true`.

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import loadFromFiles from './loadFromFiles';
  */
 export interface ConfigArray extends Array<ConfigValue> {} // eslint-disable-line
 export type ConfigObject = { [Key in string]?: ConfigValue };
-export type ConfigValue = 
+export type ConfigValue =
   | string
   | number
   | boolean
@@ -68,10 +68,12 @@ export class Config {
 
     this.settings = loadFromFiles(defaultDir, resolvedOptions.enableJs);
     this.settings = merge(this.settings, loadFromFiles(envDir, resolvedOptions.enableJs));
-    this.settings = merge(
-      this.settings,
-      loadFromFiles(localDir, resolvedOptions.enableJs)
-    );
+    if (process.env.BIG_CONFIG_DISABLE_LOCAL !== 'true') {
+      this.settings = merge(
+        this.settings,
+        loadFromFiles(localDir, resolvedOptions.enableJs)
+      );
+    }
 
     this.settings = merge(this.settings, loadFromEnv(resolvedOptions.prefix));
   }

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -23,7 +23,38 @@ describe('Config class', () => {
       },
     });
   });
-
+  it('should load local directory when process.env.BIG_CONFIG_DISABLE_LOCAL!=="true"', () => {
+    td.replace(process, 'env');
+    process.env.NODE_ENV = 'development';
+    process.env.BIG_CONFIG_DISABLE_LOCAL = 'false';
+    const fixtureDir = path.resolve(__dirname, 'fixtures', 'bigConfigLocalDisabled');
+    const config = new Config({ dir: fixtureDir });
+    assert.strictEqual(config.env, 'development');
+    assert.deepStrictEqual(config.get(), {
+      logging: {
+        logLevel: 'debug',
+        destination: 'debug.log.host',
+        colorize: true,
+        localEnabled: true,
+      },
+    });
+  });
+  it('should NOT load local directory when process.env.BIG_CONFIG_DISABLE_LOCAL==="true"', () => {
+    td.replace(process, 'env');
+    process.env.NODE_ENV = 'development';
+    process.env.BIG_CONFIG_DISABLE_LOCAL = 'true';
+    const fixtureDir = path.resolve(__dirname, 'fixtures', 'bigConfigLocalDisabled');
+    const config = new Config({ dir: fixtureDir });
+    assert.strictEqual(config.env, 'development');
+    assert.deepStrictEqual(config.get(), {
+      logging: {
+        logLevel: 'debug',
+        destination: 'debug.log.host',
+        colorize: false,
+        localEnabled: false,
+      },
+    });
+  });
   it('should include legacy JavaScript when set in options', () => {
     td.replace(process, 'env');
     td.replace(console, 'warn');

--- a/test/fixtures/bigConfigLocalDisabled/default/legacy.js
+++ b/test/fixtures/bigConfigLocalDisabled/default/legacy.js
@@ -1,0 +1,3 @@
+module.exports = {
+  legacyJavaScript: 'hello',
+};

--- a/test/fixtures/bigConfigLocalDisabled/default/logging.json5
+++ b/test/fixtures/bigConfigLocalDisabled/default/logging.json5
@@ -1,0 +1,4 @@
+{
+  logLevel: 'info',
+  colorize: false
+}

--- a/test/fixtures/bigConfigLocalDisabled/development/logging.json5
+++ b/test/fixtures/bigConfigLocalDisabled/development/logging.json5
@@ -1,0 +1,5 @@
+{
+  logLevel: 'debug',
+  destination: 'debug.log.host',
+  localEnabled: false,
+}

--- a/test/fixtures/bigConfigLocalDisabled/local/logging.json5
+++ b/test/fixtures/bigConfigLocalDisabled/local/logging.json5
@@ -1,0 +1,4 @@
+{
+  colorize: true,
+  localEnabled: true
+}

--- a/test/fixtures/bigConfigLocalDisabled/production/logging.json5
+++ b/test/fixtures/bigConfigLocalDisabled/production/logging.json5
@@ -1,0 +1,3 @@
+{
+  destination: 'production.log.host'
+}


### PR DESCRIPTION
This pull request adds the ability to disable loading local configuration by setting the `BIG_CONFIG_DISABLE_LOCAL` environment variable to `true`.

I need to do a version bump, but I will accept your guidance on how to handle that.